### PR TITLE
Fix whitespace in completions

### DIFF
--- a/wolfram_kernel/wolfram_kernel.py
+++ b/wolfram_kernel/wolfram_kernel.py
@@ -612,7 +612,7 @@ class WolframKernel(ProcessMetaKernel):
         info['obj'] + "*\"]}];$Line=$Line-1;"
         output = self.wrapper.run_command(query, timeout=-1,
                                           stream_handler=None)
-        lines = [s for s in output.splitlines() if s != ""]
+        lines = [s.strip() for s in output.splitlines() if s.strip() != ""]
         resp = []
         for l in lines:
             for k in range(len(l)-2):


### PR DESCRIPTION
Sometimes the completion output candidates contains whitespace. For example, if
there is no completion candidates, the output is ' '. This commit removes the
whitespace.