### PR TITLE
Fix a leading space issue on the Expreduce implementation.

### DIFF
--- a/wolfram_kernel/wolfram_kernel.py
+++ b/wolfram_kernel/wolfram_kernel.py
@@ -699,6 +699,9 @@ class WolframKernel(ProcessMetaKernel):
             output = self.wrapper.run_command(
                 code.rstrip(), timeout=-1, stream_handler=stream_handler
             )
+	    # Maybe strip a leading space.
+            if output[0] == ' ':
+                output = output[1:]
             # TODO:  instead of proccess_response, it would be better
             # to capture the prints and warnings at the moment they are sended.
             output = self.process_response(output)


### PR DESCRIPTION
Otherwise, it was printing some ugly "--->" for every command at the beginning.